### PR TITLE
Added grunt colorguard task

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -136,6 +136,14 @@ module.exports = function(grunt) {
       }
     },
 
+    // Scan CSS colors with Colorguard
+    colorguard: {
+      options: {},
+      files: {
+        src: ['<%= DEV_DIR %>/style.css']
+      }
+    },
+
     // Sets up grunt to watch for file changes and fire the appropriate task
     watch: {
       sass: {
@@ -199,6 +207,7 @@ module.exports = function(grunt) {
     'concat:footer',
     'concat:single',
     'sass:dev',
-    'imagemin:all'
+    'imagemin:all',
+    'colorguard'
   ]);
 };

--- a/app/templates/package.json
+++ b/app/templates/package.json
@@ -14,6 +14,7 @@
     "grunt": "~0.4.1",
     "load-grunt-tasks": "~0.4.0",
     "grunt-devtools": "~0.2.1",
+    "grunt-colorguard": "~0.1.3",
     "grunt-contrib-jshint": "~0.9.0",
     "grunt-contrib-concat": "~0.4.0",
     "grunt-contrib-uglify": "~0.4.0",


### PR DESCRIPTION
Adds [CSS Colorguard](https://github.com/SlexAxton/css-colorguard) as a grunt task during dev build
### Changes
- Added [grunt-colorguard](https://github.com/elliottwilliams/grunt-colorguard) to `packages.json`
- Added `colorguard` to `build:dev` task in `Gruntfile` template
### Review

@germanny 
@ericrasch 
@jameswlane 
### Notes

CSS Colorguard is awesome for catching colors that are indistinguishable by the average user. Awesome for reducing unnecessary stylesheet overhead.
