### PR TITLE
Fixed includes for post previews

### DIFF
--- a/app/templates/themes/evolution-parent-theme/404.php
+++ b/app/templates/themes/evolution-parent-theme/404.php
@@ -18,7 +18,7 @@
       if ( $query->have_posts() ) while ( $query->have_posts() ) : $query->the_post();
     ?>
 
-      <?php include_once( PARENT_TMPL_DIR . '/modules/mod-post-preview.php' ); ?>
+      <?php include( PARENT_TMPL_DIR . '/modules/mod-post-preview.php' ); ?>
 
     <?php
       endwhile;

--- a/app/templates/themes/evolution-parent-theme/archive.php
+++ b/app/templates/themes/evolution-parent-theme/archive.php
@@ -31,7 +31,7 @@
     <ul class="preview-list preview-list--archive">
     <?php if( have_posts() ) while ( have_posts() ) : the_post(); ?>
 
-      <?php include_once( PARENT_TMPL_DIR . '/modules/mod-post-preview.php' ); ?>
+      <?php include( PARENT_TMPL_DIR . '/modules/mod-post-preview.php' ); ?>
 
     <?php endwhile; ?>
     </ul>

--- a/app/templates/themes/evolution-parent-theme/front-page.php
+++ b/app/templates/themes/evolution-parent-theme/front-page.php
@@ -12,7 +12,7 @@
       if ( $query->have_posts() ) while ( $query->have_posts() ) : $query->the_post();
     ?>
 
-      <?php include_once( PARENT_TMPL_DIR . '/modules/mod-post-preview.php' ); ?>
+      <?php include( PARENT_TMPL_DIR . '/modules/mod-post-preview.php' ); ?>
 
     <?php
       endwhile;

--- a/app/templates/themes/evolution-parent-theme/home.php
+++ b/app/templates/themes/evolution-parent-theme/home.php
@@ -17,7 +17,7 @@
       if( $query->have_posts() ) while ( $query->have_posts() ) : $query->the_post();
     ?>
 
-      <?php include_once( PARENT_TMPL_DIR . '/modules/mod-post-preview.php' ); ?>
+      <?php include( PARENT_TMPL_DIR . '/modules/mod-post-preview.php' ); ?>
 
     <?php endwhile; ?>
     </ul>

--- a/app/templates/themes/evolution-parent-theme/search.php
+++ b/app/templates/themes/evolution-parent-theme/search.php
@@ -12,7 +12,7 @@
     <ul class="preview-list preview-list--results">
     <?php if ( have_posts() ) while ( have_posts() ) : the_post(); ?>
 
-      <?php include_once( PARENT_TMPL_DIR . '/modules/mod-post-preview.php' ); ?>
+      <?php include( PARENT_TMPL_DIR . '/modules/mod-post-preview.php' ); ?>
 
     <?php endwhile; ?>
     </ul>


### PR DESCRIPTION
Fixes includes for post previews (`include_once` won't work in a loop)
### Changes
- Changed all post-preview `include_once()` instances to `include()`.
### Review

@germanny 
@ericrasch 
@jameswlane 
### Notes
