### PR TITLE
Fixed pagination output

### DIFF
--- a/app/templates/themes/evolution-child-theme/functions/pagination.php
+++ b/app/templates/themes/evolution-child-theme/functions/pagination.php
@@ -34,15 +34,15 @@ function pagination( $pages = '', $range = 2 ) {
   if ( $pages != 1 ) {
     echo '<ol class="pagination">';
     if ( $paged > 1 ) echo '<li class="pagination__prev"><a href="' . get_pagenum_link( $paged - 1 ) . '" rel="prev">Previous</a></li>';
-    if ( $paged > 2 && $paged > ( $range + 1 ) && $showitems < $pages ) echo '<li><a href="' . get_pagenum_link(1) . '">1</a></li>\n<li class="pagination__more"><span>&#8230;</span></li>';
+    if ( $paged > 2 && $paged > ( $range + 1 ) && $showitems < $pages ) echo '<li><a href="' . get_pagenum_link(1) . '">1</a></li>' . "\n" . '<li class="pagination__more"><span>&#8230;</span></li>';
 
     for ( $i = 1; $i <= $pages; $i++ ) {
       if ( 1 != $pages && ( !( $i >= ( $paged + $range + 1 ) || $i <= ( $paged - $range - 1 ) ) || $pages <= $showitems ) ) {
-        echo ( $paged == $i ) ? '<li class="pagination__curr"><span>' . $i . '</span>' : '<a href="' . get_pagenum_link( $i ) . '">' . $i . '</a>'; // This line displays the page number links
+        echo ( $paged == $i ) ? '<li class="pagination__curr"><span>' . $i . '</span></li>' : '<li><a href="' . get_pagenum_link( $i ) . '">' . $i . '</a></li>'; // This line displays the page number links
       }
     }
 
-    if ( $paged < ( $pages - 1 ) && ( $paged + $range - 1 ) < $pages && $showitems < $pages ) echo '<li class="pagination__more"><span>&#8230;</span></li>\n<li><a href="' . get_pagenum_link( $pages ) . '">' . $pages . '</a></li>';
+    if ( $paged < ( $pages - 1 ) && ( $paged + $range - 1 ) < $pages && $showitems < $pages ) echo '<li class="pagination__more"><span>&#8230;</span></li>' . "\n" . '<li><a href="' . get_pagenum_link( $pages ) . '">' . $pages . '</a></li>';
     if ( $paged < $pages ) echo '<li class="pagination__next"><a href="' . get_pagenum_link( $paged + 1 ) . '" rel="next">Next</a></li>';
     echo '</ol>';
   }


### PR DESCRIPTION
Fixes incorrect list item and new line output in the pagination function
### Changes
- Closed and opened the `li` on each side of the ternary values
- Wrapped `\n` in double quotes to properly expand in php
### Review

@germanny 
@ericrasch 
@jameswlane 
### Notes
