### PR TITLE
Fix display thumbnails

### DIFF
--- a/app/templates/themes/evolution-child-theme/functions/display-post-thumbnails.php
+++ b/app/templates/themes/evolution-child-theme/functions/display-post-thumbnails.php
@@ -51,9 +51,10 @@ function display_post_thumbnail( $id = 0, $size = 'thumbnail' ) {
 
   if ( display_post_thumbnail_src( $post_id, $size ) ) {
 
+    $link       = get_permalink( $post_id );
+
     if ( $src == DEFAULT_PHOTO ) {
       $class    = ' default-photo';
-      $link     = get_permalink( $post_id );
       $img_src  = DEFAULT_PHOTO;
     } else {
       $class    = '';


### PR DESCRIPTION
Something happened to this function along the way and it stopped displaying thumbnails. `display_post_thumbnail_src()` was creating an array of urls to thumbnails in the post, and `display_post_thumbnail()` had a mysterious `$src` param with a value that could never be equivalent to the output of `display_post_thumbnail_src()`. So it displayed nothing. We just need one image url or the `DEFAULT_PHOTO` constant returned from `display_post_thumbnail_src()`, and `display_post_thumbnail()` just needs to check if `display_post_thumbnail_src()` has a value and display it along with the right class. I think we were trying to be too fancy.
